### PR TITLE
Update README sample command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The easiest way to run application locally is to use _LocalLibraryApplication_ c
 
 To enable Actuator endpoints admin profile has to be activated with proper secrets provided via system properties or other suitable external configuration option:
 
-> _-Dspring.security.user.name=admin -Dspring.security.user.password=xpinjection -Dspring.profiles.active=dev,admin_
+> `-Dspring.security.user.name=admin -Dspring.security.user.password=xpinjection -Dspring.profiles.active=dev,admin`
 
 ## Consumer-driven contracts
 


### PR DESCRIPTION
## Summary
- format the sample command line using backticks instead of underscores