### PR TITLE
Remove noisy console output from ExpertApiTest

### DIFF
--- a/src/test/java/com/xpinjection/library/adaptors/api/AbstractApiTest.java
+++ b/src/test/java/com/xpinjection/library/adaptors/api/AbstractApiTest.java
@@ -6,7 +6,6 @@ import com.github.viclovsky.swagger.coverage.SwaggerCoverageV3RestAssured;
 import com.xpinjection.library.RuntimeDependencies;
 import io.restassured.RestAssured;
 import io.restassured.specification.RequestSpecification;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.springdoc.core.properties.SwaggerUiConfigParameters;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +18,6 @@ import java.nio.file.Path;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DBRider
-@Slf4j
 @ActiveProfiles("test")
 @ImportTestcontainers(RuntimeDependencies.class)
 public abstract class AbstractApiTest {

--- a/src/test/java/com/xpinjection/library/adaptors/api/ExpertApiTest.java
+++ b/src/test/java/com/xpinjection/library/adaptors/api/ExpertApiTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 
 import static java.util.Collections.singletonMap;
@@ -36,10 +37,11 @@ public class ExpertApiTest extends AbstractApiTest {
     }
 
     @TestConfiguration
+    @Slf4j
     public static class BookTestContext {
         @Bean
         public CommandLineRunner bookInitializer(BookService bookService) {
-            System.out.println("!!! Insert test data");
+            LOG.info("Insert test data");
             return (args) -> bookService.addBooks(
                     Books.fromMap(singletonMap("Effective Java", "Josh Bloch")));
         }


### PR DESCRIPTION
## Summary
- drop Lombok `@Slf4j` from the API test base
- log test data setup in `ExpertApiTest` using Lombok's logger