### PR TITLE
Add option to skip Testcontainers tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ Pact integration could be enabled during tests execution with `pactbroker.enable
 Use system variable `pact.verifier.publishResults` to control pact verification results publishing to the Pact Broker. Pact Broker configuration is located in `pom.xml` and could be overridden with system properties as well.
 
 System properties `pact.provider.version` and `pact.provider.branch` should be used to pass correct version of the application and git branch for tracking in the Pact Broker.
+
+## Skipping Testcontainers based tests
+
+Tests that rely on Testcontainers can be disabled by setting system property `testcontainers.enabled` to `false`:
+
+```bash
+./mvnw verify -Dtestcontainers.enabled=false
+```

--- a/src/test/java/com/xpinjection/library/adaptors/api/AbstractApiTest.java
+++ b/src/test/java/com/xpinjection/library/adaptors/api/AbstractApiTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.testcontainers.context.ImportTestcontainers;
 import org.springframework.test.context.ActiveProfiles;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import java.nio.file.Path;
 
@@ -20,6 +21,7 @@ import java.nio.file.Path;
 @DBRider
 @ActiveProfiles("test")
 @ImportTestcontainers(RuntimeDependencies.class)
+@DisabledIfSystemProperty(named = "testcontainers.enabled", matches = "false")
 public abstract class AbstractApiTest {
     private static final ApiReports REPORTS = ApiReports.builder()
             .coveragePath(Path.of("target", "api-coverage"))

--- a/src/test/java/com/xpinjection/library/adaptors/persistence/AbstractDaoTest.java
+++ b/src/test/java/com/xpinjection/library/adaptors/persistence/AbstractDaoTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.testcontainers.context.ImportTestcontainers;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import java.util.Map;
 import java.util.stream.Stream;
@@ -23,6 +24,7 @@ import java.util.stream.Stream;
 @DBRider
 @ActiveProfiles("test")
 @ImportTestcontainers(RuntimeDependencies.class)
+@DisabledIfSystemProperty(named = "testcontainers.enabled", matches = "false")
 public abstract class AbstractDaoTest<D> {
     private static long ID = 1000;
 

--- a/src/test/java/com/xpinjection/library/adaptors/ui/BookUITest.java
+++ b/src/test/java/com/xpinjection/library/adaptors/ui/BookUITest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.testcontainers.context.ImportTestcontainers;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.htmlunit.MockMvcWebClientBuilder;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.io.IOException;
@@ -33,6 +34,7 @@ import static org.hamcrest.Matchers.containsString;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("test")
 @ImportTestcontainers(RuntimeDependencies.class)
+@DisabledIfSystemProperty(named = "testcontainers.enabled", matches = "false")
 public class BookUITest {
     @Autowired
     private WebApplicationContext context;


### PR DESCRIPTION
## Summary
- allow disabling Testcontainers-based tests via `testcontainers.enabled=false`
- document how to skip these tests

## Testing
- `sh mvnw verify` *(fails: Could not find or load main class org.apache.maven.wrapper.MavenWrapperMain)*