### PR TITLE
Disable testcontainers-based tests when flagged

### DIFF
--- a/src/test/java/com/xpinjection/library/adaptors/api/BookApiTest.java
+++ b/src/test/java/com/xpinjection/library/adaptors/api/BookApiTest.java
@@ -4,10 +4,12 @@ import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.SeedStrategy;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.http.MediaType;
 
 import static org.hamcrest.Matchers.*;
 
+@DisabledIfSystemProperty(named = "testcontainers.enabled", matches = "false")
 public class BookApiTest extends AbstractApiTest {
     @Test
     @DataSet(value = "default-books.xml", strategy = SeedStrategy.REFRESH)

--- a/src/test/java/com/xpinjection/library/adaptors/api/ExpertApiTest.java
+++ b/src/test/java/com/xpinjection/library/adaptors/api/ExpertApiTest.java
@@ -4,6 +4,7 @@ import com.xpinjection.library.service.BookService;
 import com.xpinjection.library.service.dto.Books;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -13,6 +14,7 @@ import org.springframework.http.MediaType;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@DisabledIfSystemProperty(named = "testcontainers.enabled", matches = "false")
 public class ExpertApiTest extends AbstractApiTest {
     @Test
     /*@ExportDataSet(format = DataSetFormat.XML, outputName = "target/expert-added.xml",

--- a/src/test/java/com/xpinjection/library/adaptors/persistence/BookDaoTest.java
+++ b/src/test/java/com/xpinjection/library/adaptors/persistence/BookDaoTest.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableMap;
 import com.xpinjection.library.domain.Book;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.test.context.jdbc.Sql;
 
@@ -15,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * @author Alimenkou Mikalai
  */
+@DisabledIfSystemProperty(named = "testcontainers.enabled", matches = "false")
 public class BookDaoTest extends AbstractDaoTest<BookDao> {
     @Nested
     class FindByNameTests {

--- a/src/test/java/com/xpinjection/library/adaptors/persistence/ExpertDaoTest.java
+++ b/src/test/java/com/xpinjection/library/adaptors/persistence/ExpertDaoTest.java
@@ -5,6 +5,7 @@ import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.xpinjection.library.adaptors.persistence.entity.ExpertEntity;
 import com.xpinjection.library.domain.Book;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.transaction.TestTransaction;
@@ -13,6 +14,7 @@ import static com.google.common.collect.Sets.newHashSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@DisabledIfSystemProperty(named = "testcontainers.enabled", matches = "false")
 public class ExpertDaoTest extends AbstractDaoTest<ExpertDao> {
     @Test
     @DataSet(executeStatementsBefore = "ALTER SEQUENCE expert_id_seq RESTART WITH 1",


### PR DESCRIPTION
## Summary
- ensure concrete test classes are disabled when `testcontainers.enabled=false`
- now `mvn verify` succeeds with the flag disabled

## Testing
- `mvn --batch-mode -Dstyle.color=never verify -Dtestcontainers.enabled=false --offline`

------
https://chatgpt.com/codex/tasks/task_e_68545472311c83298b710bde35726641